### PR TITLE
Fix: Pban commands throwing errors

### DIFF
--- a/src/IncludedCommands/Resources/PersistentBans.lua
+++ b/src/IncludedCommands/Resources/PersistentBans.lua
@@ -62,6 +62,8 @@ function PersistentBans:Initialize()
             self:FetchBannedPlayers()
         end)
         if not Worked then
+            -- Set the BannedUsers to an empty table if the fetch failed
+            self.BannedUsers = {}
             warn("Fetching bans failed because "..tostring(Return))
             return
         end
@@ -149,15 +151,7 @@ end
 Fetches the banned players.
 --]]
 function PersistentBans:FetchBannedPlayers()
-    local Worked,BannedUsers = pcall(function()
-		return self.DataStore:GetAsync("PercistentBans")
-    end)
-    
-	if Worked then
-		self.BannedUsers = BannedUsers or {}
-	else
-		self.BannedUsers = {}
-	end
+    self.BannedUsers = self.DataStore:GetAsync("PercistentBans") or {}
 
     --Kick the banned players.
     for _,Player in pairs(self.Players:GetPlayers()) do

--- a/src/IncludedCommands/Resources/PersistentBans.lua
+++ b/src/IncludedCommands/Resources/PersistentBans.lua
@@ -62,8 +62,6 @@ function PersistentBans:Initialize()
             self:FetchBannedPlayers()
         end)
         if not Worked then
-            -- Set the BannedUsers to an empty table if the fetch failed
-            self.BannedUsers = {}
             warn("Fetching bans failed because "..tostring(Return))
             return
         end

--- a/src/IncludedCommands/Resources/PersistentBans.lua
+++ b/src/IncludedCommands/Resources/PersistentBans.lua
@@ -149,7 +149,15 @@ end
 Fetches the banned players.
 --]]
 function PersistentBans:FetchBannedPlayers()
-    self.BannedUsers = self.DataStore:GetAsync("PercistentBans")
+    local Worked,BannedUsers = pcall(function()
+		return self.DataStore:GetAsync("PercistentBans")
+    end)
+    
+	if Worked then
+		self.BannedUsers = BannedUsers or {}
+	else
+		self.BannedUsers = {}
+	end
 
     --Kick the banned players.
     for _,Player in pairs(self.Players:GetPlayers()) do


### PR DESCRIPTION
Pbans command throws an error when the datastore is not filled with existing ban data, causing the following error to be thrown:

```
23:46:03.007 - ServerScriptService.NexusAdmin.IncludedCommands.Persistent.pbans:46: invalid argument #1 to 'pairs' (table expected, got nil)
23:46:03.008 - Stack Begin
23:46:03.008 - Script 'ServerScriptService.NexusAdmin.IncludedCommands.Persistent.pbans', Line 46 - function OnServerInvoke
23:46:03.008 - Stack End
```

Similary the pban command was also broken due to the fact it was trying to index the BannedUsers table (which is nil) to store the new ban on the table.

```
23:49:47.628 - ServerScriptService.NexusAdmin.IncludedCommands.Resources.PersistentBans:167: attempt to index nil with '1'
```

Added a change which loads the ban data or when not present defaults to an empty table, causing all pban commands to properly function.