### PR TITLE
Shallow support for Cmdr conditional arguments

### DIFF
--- a/src/Client/ClientRegistry.lua
+++ b/src/Client/ClientRegistry.lua
@@ -58,13 +58,13 @@ function ClientRegistry:LoadCommand(CommandData: Types.NexusAdminCommandData): (
     end
 
     -- Force arguments lost during invocation to be included on the client. Extremely shallow.
-	if ExistingCommand then
-		for index,arg in ipairs(ExistingCommand.Args) do
-			if typeof(CmdrCommandData.Args[index]) ~= typeof(arg) then
-				table.insert(CmdrCommandData.Args,index,arg)
-			end
-		end
-	end
+    if ExistingCommand then
+        for i, Argument in ExistingCommand.Args do
+            if typeof(CmdrCommandData.Args[i]) ~= typeof(Argument) then
+                table.insert(CmdrCommandData.Args, i, Argument)
+            end
+        end
+    end
     
     self.Cmdr.Registry:RegisterCommandObject(CmdrCommandData)
 end

--- a/src/Client/ClientRegistry.lua
+++ b/src/Client/ClientRegistry.lua
@@ -56,6 +56,16 @@ function ClientRegistry:LoadCommand(CommandData: Types.NexusAdminCommandData): (
     elseif ExistingCommand then
         CmdrCommandData.ClientRun = ExistingCommand.ClientRun
     end
+
+    -- Force arguments lost during invocation to be included on the client. Extremely shallow.
+	if ExistingCommand then
+		for index,arg in ipairs(ExistingCommand.Args) do
+			if typeof(CmdrCommandData.Args[index]) ~= typeof(arg) then
+				table.insert(CmdrCommandData.Args,index,arg)
+			end
+		end
+	end
+    
     self.Cmdr.Registry:RegisterCommandObject(CmdrCommandData)
 end
 

--- a/src/IncludedCommands/Administrative/cmds.lua
+++ b/src/IncludedCommands/Administrative/cmds.lua
@@ -44,15 +44,15 @@ return {
                         for _,Prefix in Prefixes do
                             local CommandString = Prefix..CmdrCommand.Name.." "
                             for _,Argument in CmdrCommand.Args do
-                                if typeof(Argument)=='function' then
-									CommandString = CommandString.."[Conditional] "
-								else
-	                                if Argument.Optional == true then
+                                if typeof(Argument) == "function" then
+                                    CommandString = CommandString.."[Conditional] "
+                                else
+                                    if Argument.Optional == true then
 	                                    CommandString = CommandString.."("..Argument.Name..") "
-	                                else
-	                                    CommandString = CommandString..Argument.Name.." "
-									end
-								end
+                                    else
+                                        CommandString = CommandString..Argument.Name.." "
+                                    end
+                                end
                             end
                             if not ExistingLines[CommandString] and string.find(string.lower(CommandString), string.lower(SearchTerm)) then
                                 table.insert(Commands,CommandString.."- "..CmdrCommand.Description)

--- a/src/IncludedCommands/Administrative/cmds.lua
+++ b/src/IncludedCommands/Administrative/cmds.lua
@@ -44,11 +44,15 @@ return {
                         for _,Prefix in Prefixes do
                             local CommandString = Prefix..CmdrCommand.Name.." "
                             for _,Argument in CmdrCommand.Args do
-                                if Argument.Optional == true then
-                                    CommandString = CommandString.."("..Argument.Name..") "
-                                else
-                                    CommandString = CommandString..Argument.Name.." "
-                                end
+                                if typeof(Argument)=='function' then
+									CommandString = CommandString.."[Conditional] "
+								else
+	                                if Argument.Optional == true then
+	                                    CommandString = CommandString.."("..Argument.Name..") "
+	                                else
+	                                    CommandString = CommandString..Argument.Name.." "
+									end
+								end
                             end
                             if not ExistingLines[CommandString] and string.find(string.lower(CommandString), string.lower(SearchTerm)) then
                                 table.insert(Commands,CommandString.."- "..CmdrCommand.Description)

--- a/src/IncludedCommands/Administrative/cmds.lua
+++ b/src/IncludedCommands/Administrative/cmds.lua
@@ -48,7 +48,7 @@ return {
                                     CommandString = CommandString.."[Conditional] "
                                 else
                                     if Argument.Optional == true then
-	                                    CommandString = CommandString.."("..Argument.Name..") "
+                                        CommandString = CommandString.."("..Argument.Name..") "
                                     else
                                         CommandString = CommandString..Argument.Name.." "
                                     end

--- a/src/IncludedCommands/BasicCommands/playerstep.lua
+++ b/src/IncludedCommands/BasicCommands/playerstep.lua
@@ -18,7 +18,7 @@ return {
         {
             Type = "nexusAdminPlayers",
             Name = "Players",
-            Description = "Players to run the command one.",
+            Description = "Players to run the command on.",
         },
         {
             Type = "string",


### PR DESCRIPTION
Allows for the conditional (function) arguments in evaera/Cmdr to be properly registered by the client and thus work as expected, also allows `cmds` to still run without throwing errors, and at least displays some hint that there is additional arguments.

Proposed fix for #17 