### PR TITLE
Minor Touchpad Flight Bug, Docs Changes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -220,7 +220,7 @@ Displays a full-screen message to the specified player.
 #### `Messages:DisplayNotification(TopText: string, Message: string, DisplayTime: number?): ()` *Client-Only*
 Displays a slide-in notification to the local player.
 
-#### `Messages:DisplayNotification(TopText: string, Message: string, DisplayTime: number?): ()` *Server-Only*
+#### `Messages:DisplayNotification(Player: Player, TopText: string, Message: string, DisplayTime: number?): ()` *Server-Only*
 Displays a slide-in notification to the specified player.
 
 ### `Types`

--- a/docs/included-feature-flags.md
+++ b/docs/included-feature-flags.md
@@ -9,12 +9,12 @@ If true, the native messages GUI will be displayed when
 is displayed intended for the developer to replace.
 
 ## UseNativeHintGui (default: `true`)
-If true, the native hits GUI will be displayed when
+If true, the native hints GUI will be displayed when
 `Messages:DisplayHint()` is used. If false, no GUI
 is displayed intended for the developer to replace.
 
 ## UseNativeNotificationGui (default: `true`)
-If true, the native hits GUI will be displayed when
+If true, the native notification GUI will be displayed when
 `Messages:DisplayNotification()` is used. If false, no GUI
 is displayed intended for the developer to replace.
 
@@ -29,4 +29,16 @@ prefixes used. If false, chat executing will be ignored.
 
 ## AllowDroppingSwords (default: `true`)
 If true, players will be able to drop swords. 
+If false, they won't.
+
+## PreformSoftShutdownOnClose (default: `true`)
+If true, the server will automaticly preform a SoftShutdown on `game:BindToClose()`.
+If false, it will not.
+
+## UseBeamsWhenTracking (default: `true`)
+If true, beams will be drawn to each player's character when running `:track`.
+If false, no beams will be drawn.
+
+## AllowFlyingThroughMap (default: `true`)
+If true, players will be able to fly through the map when using `:fly`.
 If false, they won't.

--- a/src/IncludedCommands/UsefulFun/fly.lua
+++ b/src/IncludedCommands/UsefulFun/fly.lua
@@ -328,10 +328,10 @@ return {
                                 Flight.KeysDown[Enum.KeyCode.D] = false
                             end
 
-                            if Y <= -0.5 then
+                            if Y <= -0.1 then
                                 Flight.KeysDown[Enum.KeyCode.S] = true
                                 Flight.KeysDown[Enum.KeyCode.W] = false
-                            elseif Y >= 0.5 then
+                            elseif Y >= 0.1 then
                                 Flight.KeysDown[Enum.KeyCode.S] = false
                                 Flight.KeysDown[Enum.KeyCode.W] = true
                             else
@@ -353,7 +353,7 @@ return {
                     table.insert(Flight.Events, Flight.Humanoid:GetPropertyChangedSignal("MoveDirection"):Connect(function()
                         -- Stop the flight movement when the Humanoid has no Movement Direction
                         local MoveDirection = Flight.Humanoid.MoveDirection
-                        if MoveDirection.X < 0.5 and MoveDirection.X > -0.5 and MoveDirection.Z < 0.5 and MoveDirection.Z > -0.5 then
+                        if MoveDirection.X < 0.5 and MoveDirection.X > -0.5 and MoveDirection.Z < 0.1 and MoveDirection.Z > -0.1 then
                             Flight.KeysDown[Enum.KeyCode.W] = false
                             Flight.KeysDown[Enum.KeyCode.S] = false
                             Flight.KeysDown[Enum.KeyCode.A] = false


### PR DESCRIPTION
- Changed W and S minimum absolute position from .5 to .1
  - Fixes bug with touchpad flight being unable to move forward or backwards when looking directly up or directly down

- Added missing Included FeatureFlags to [included-feature-flags.md](https://github.com/TheNexusAvenger/Nexus-Admin/blob/master/docs/included-feature-flags.md)
  - PreformSoftShutdownOnClose
  - UseBeamsWhenTracking
  - AllowFlyingThroughMap
- Fixed Typo under `UseNativeHintGui`
- Fixed Type under `UseNativeNotificationGui`

- Added missing `Player: Player` argument for server `Messages:DisplayNotification()` in [api.md](https://github.com/TheNexusAvenger/Nexus-Admin/blob/master/docs/api.md)